### PR TITLE
Removing (commenting) kwargs.pop('encoding', None)

### DIFF
--- a/intercom2/json.py
+++ b/intercom2/json.py
@@ -20,7 +20,7 @@ class IntercomFormatEncoder(json.JSONEncoder):
 
 class IntercomFormatDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
-        kwargs.pop('encoding', None)
+        # kwargs.pop('encoding', None)
         json.JSONDecoder.__init__(
             self, object_hook=self.object_hook, *args, **kwargs)
 


### PR DESCRIPTION
The argument encoding was removed from json.loads in Python 3.9 (it was deprecated since Python 3.1).